### PR TITLE
set the correct cnn type according to the weights filename

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -167,10 +167,11 @@ if __name__ == "__main__":
     else:
       encoder = torch.load(args.encoding_file)
     print ("creating model...") 
-    model = getattr(model_module, mod_name)(encoder)
     if args.weights_file is None:
       print ("expecting weight file to run features")
       exit()
+    cnn_type = os.path.basename(args.weights_file).split('_', maxsplit=1)[1]
+    model = getattr(model_module, mod_name)(encoder, cnn_type=cnn_type)
     
     print ("loading model weights...")
     model.load_state_dict(torch.load(args.weights_file))


### PR DESCRIPTION
Solve the loading problems mentioned in this closed issue:
https://github.com/my89/imSitu/issues/3#issuecomment-469077352

Because class `baseline_crf ` has a default parameter [`cnn_type='resenet_101'`](https://github.com/my89/imSitu/blob/master/baseline_crf.py#L138), the `eval.py` will always try to load the weights to the resnet101 model. That's why other models can not be loaded correctly.